### PR TITLE
Add default sample rate detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The config.json file contains five fields that control how Kalamagic runs:
 * `outputDevice`: This is the name of the audio output device. As with the input device, you will be prompted if this does not exist, and the configuration file will be updated.
 * `bufferLength`: This is how long the *buffer* is, i.e. how much audio the program will work with at a time. It takes time to do the audio computations, so if this length is too low, you will see `! BUFFER OVERRUN !` in the console, and the audio will sound distorted. If this happens, increase the setting and restart the program.
 * `historyLength`: This is how much previous audio Kalamagic keeps track of. If this value is too short, some audio effects will sound distorted, but the program's RAM usage will be proportional to this value.
-* `sampleRate`: This is the sample rate used by the program. You should probably set this to be equal to the sample rate of your microphone, but you can lower it if your CPU isn't fast enough for a given filter.
+* `sampleRate`: This is the sample rate (an integer) used by the program. You should probably set this to be equal to the sample rate of your microphone, but you can try lowering it if your CPU isn't fast enough for a given filter. By default, it is `-1`, meaning the program will automatically use the default sample rate of the input and output devices, so long as they match. Some systems may restrict the sample rate to either match the default, or be limited to specific values; the program will give an error if the chosen sample rate isn't supported by your system.
 
 ### Filter Files
 

--- a/defaults.json
+++ b/defaults.json
@@ -3,5 +3,5 @@
     "outputDevice": "",
     "bufferLength": 2048,
     "historyLength": 512000,
-    "sampleRate": 44100
+    "sampleRate": -1
 }

--- a/kalamagic.py
+++ b/kalamagic.py
@@ -91,7 +91,7 @@ if RATE < 0:
         print('User did not specify a custom sample rate, using default rate of', RATE)
     else:
         print('Default input/output sample rates did not match and user did not set a custom one!')
-        print('Default input rate:', defaultInputRate, ' Default output rate:', defaultOutputRate)
+        print('Default input rate:', defaultInputRate, 'Default output rate:', defaultOutputRate)
         sys.exit(0)
 
 config['inputDevice'] = getDeviceFullName(int(choice)-1)

--- a/kalamagic.py
+++ b/kalamagic.py
@@ -83,6 +83,17 @@ if not choice2.isdigit():
 if terminate:
     sys.exit(0)
 
+if RATE < 0:
+    defaultInputRate = p.get_device_info_by_index(int(choice)-1).get('defaultSampleRate')
+    defaultOutputRate = p.get_device_info_by_index(int(choice2)-1).get('defaultSampleRate')
+    if defaultOutputRate == defaultInputRate:
+        print('User did not specify a custom sample rate, using default rate of', defaultOutputRate)
+        RATE = int(defaultOutputRate)
+    else:
+        print('Default input/output sample rates did not match and user did not set a custom one!')
+        print('Default input rate:', defaultInputRate, ' Default output rate:', defaultOutputRate)
+        sys.exit(0)
+
 config['inputDevice'] = getDeviceFullName(int(choice)-1)
 config['outputDevice'] = getDeviceFullName(int(choice2)-1)
 

--- a/kalamagic.py
+++ b/kalamagic.py
@@ -87,8 +87,8 @@ if RATE < 0:
     defaultInputRate = p.get_device_info_by_index(int(choice)-1).get('defaultSampleRate')
     defaultOutputRate = p.get_device_info_by_index(int(choice2)-1).get('defaultSampleRate')
     if defaultOutputRate == defaultInputRate:
-        print('User did not specify a custom sample rate, using default rate of', defaultOutputRate)
         RATE = int(defaultOutputRate)
+        print('User did not specify a custom sample rate, using default rate of', RATE)
     else:
         print('Default input/output sample rates did not match and user did not set a custom one!')
         print('Default input rate:', defaultInputRate, ' Default output rate:', defaultOutputRate)


### PR DESCRIPTION
Since various systems might vary in their support of different sample rates, with some not supporting 44.1kHz while others don't support 48kHz, have the program default to using the input/output devices' sample rate instead of 44.1kHz.